### PR TITLE
fix: use GADUnitIdentifiers keys as GADUnitName rawValues

### DIFF
--- a/Projects/App/Sources/Extensions/Ad/GADUnitName.swift
+++ b/Projects/App/Sources/Extensions/Ad/GADUnitName.swift
@@ -10,9 +10,9 @@ import Foundation
 
 extension SwiftUIAdManager {
     enum GADUnitName: String {
-        case launch = "ca-app-pub-9684378399371172/4877474273"
-        case full = "ca-app-pub-9684378399371172/4931504044"
-        case native = "ca-app-pub-9684378399371172/1903064527"
+        case launch = "Launch"
+        case full = "FullAd"
+        case native = "NativeAd"
     }
 
 #if DEBUG


### PR DESCRIPTION
GADUnitName enum raw values now reference the name keys defined in the GADUnitIdentifiers Info.plist dictionary (Project.swift) instead of hardcoding ad unit IDs directly. This lets GADManager resolve unit IDs from Info.plist at runtime, so adding or changing a unit ID only requires editing Project.swift.

Fixes #21

Generated with [Claude Code](https://claude.ai/code)