### PR TITLE
fix: change followCategory from var to let

### DIFF
--- a/Projects/App/Sources/Controllers/LCExcelController.swift
+++ b/Projects/App/Sources/Controllers/LCExcelController.swift
@@ -61,7 +61,7 @@ class LCExcelController : NSObject{
     }
     
     func loadFromFlie(){
-        var followCategory : LCToastCategory = .init(name: "follow", image: nil)
+        let followCategory : LCToastCategory = .init(name: "follow", image: nil)
         followCategory.name = "선창!후창~!"
         self.loadFollowToasts(withCategory: followCategory)
         self.categories.append(followCategory)


### PR DESCRIPTION
Resolves compiler warning: "Variable followCategory was never mutated; consider changing to let constant".

Since LCToastCategory is a class (reference type), mutating its properties does not require the holding variable to be var.

Closes #23

Generated with [Claude Code](https://claude.ai/code)