### PR TITLE
fix: add AccentColor to asset catalog

### DIFF
--- a/Projects/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Projects/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.871",
+          "green" : "0.262",
+          "red" : "0.479"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
Adds the missing AccentColor.colorset to resolve the Xcode warning "Accent color 'AccentColor' is not present in any asset catalogs".

The color uses the app's existing primary purple accent (0.479, 0.262, 0.871) in display-p3 color space, matching the accent used throughout the UI.

Closes #25

Generated with [Claude Code](https://claude.ai/code)