### PR TITLE
fix: requestAppTrackingIfNeed of NativeAdCell never called

### DIFF
--- a/Projects/App/Sources/Extensions/Ad/NativeAdSwiftUIView.swift
+++ b/Projects/App/Sources/Extensions/Ad/NativeAdSwiftUIView.swift
@@ -55,6 +55,9 @@ struct NativeAdSwiftUIView<Content: View>: View {
         ZStack(alignment: .center) {
             if let ad = coordinator.nativeAd {
                 NativeAdRepresentable(nativeAd: ad)
+                    .task {
+                        await adManager.requestAppTrackingIfNeed()
+                    }
             }
             contentBuilder(coordinator.nativeAd)
                 .allowsHitTesting(coordinator.nativeAd != nil ? false : true)

--- a/Projects/App/Sources/Views/NativeAdCell.swift
+++ b/Projects/App/Sources/Views/NativeAdCell.swift
@@ -90,11 +90,6 @@ struct NativeAdCell: View {
                         AdMarkView()
                             .padding(8)
                     }
-                    .task {
-                        if nativeAd != nil {
-                            await adManager.requestAppTrackingIfNeed()
-                        }
-                    }
                 }
             }
         }


### PR DESCRIPTION
Move .task for requestAppTrackingIfNeed into the `if let ad = coordinator.nativeAd` block in NativeAdSwiftUIView, so it only runs after a native ad has loaded.

# Result
<img width="606" alt="Screenshot 2026-02-10 at 11 33 06 PM" src="https://github.com/user-attachments/assets/11704962-5677-4480-aef0-2f037e2a5536" />

Closes #36

Generated with [Claude Code](https://claude.ai/code)