### PR TITLE
bump: release 2.1.0

### DIFF
--- a/Projects/App/Configs/debug.xcconfig
+++ b/Projects/App/Configs/debug.xcconfig
@@ -6,7 +6,7 @@ ENABLE_BITCODE=NO
 EXCLUDED_ARCHS[sdk=iphonesimulator*]=i386
 INFOPLIST_FILE=letscheers/Info.plist
 INFOPLIST_KEY_LSApplicationCategoryType=public.app-category.lifestyle
-MARKETING_VERSION=2.0.0
+MARKETING_VERSION=2.1.0
 PRODUCT_BUNDLE_IDENTIFIER=com.credif.letscheers
 PRODUCT_NAME=$(TARGET_NAME)
 SUPPORTED_PLATFORMS=iphoneos iphonesimulator

--- a/Projects/App/Configs/release.xcconfig
+++ b/Projects/App/Configs/release.xcconfig
@@ -6,7 +6,7 @@ ENABLE_BITCODE=NO
 EXCLUDED_ARCHS[sdk=iphonesimulator*]=i386
 INFOPLIST_FILE=letscheers/Info.plist
 INFOPLIST_KEY_LSApplicationCategoryType=public.app-category.lifestyle
-MARKETING_VERSION=2.0.0
+MARKETING_VERSION=2.1.0
 PRODUCT_BUNDLE_IDENTIFIER=com.credif.letscheers
 PRODUCT_NAME=$(TARGET_NAME)
 SUPPORTED_PLATFORMS=iphoneos iphonesimulator


### PR DESCRIPTION
## 2.1.0 패치 노트

### 새로운 기능
- **라이트/다크 모드 지원**: iOS 시스템 설정에 따라 앱 테마가 자동으로 전환됩니다.
  - 라이트 모드: 밝은 라벤더 배경, 흰색 카드
  - 다크 모드: 딥 퍼플 배경, 퍼플 계열 카드

### 개선 사항
- 카드 그림자를 퍼플 앰비언트 글로우로 교체 (다크 모드 가시성 향상)
- 내비게이션 바 배경색 적용 (라이트/다크 모드 각각 최적화)
- 내비게이션 타이틀 및 버튼 아이콘 항상 흰색으로 표시

---

## 2.1.0 Release Notes

### New Features
- **Light/Dark Mode Support**: App theme now automatically switches based on iOS system appearance setting.
  - Light mode: Soft lavender background, white cards
  - Dark mode: Deep purple background, purple-tinted cards

### Improvements
- Replaced black card shadow with purple ambient glow for better dark mode visibility
- Navigation bar background color applied with mode-appropriate tints
- Navigation title and toolbar icons always render in white for legibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)