### PR TITLE
fix: remove unused toastId warning

### DIFF
--- a/Projects/App/Sources/ViewModels/ToastListViewModel.swift
+++ b/Projects/App/Sources/ViewModels/ToastListViewModel.swift
@@ -42,7 +42,6 @@ class ToastListViewModel: ObservableObject {
     
     func toggleFavorite(for toastViewModel: ToastViewModel, modelContext: ModelContext) {
         let newValue = !toastViewModel.isFavorite
-        let toastId = toastViewModel.id
 
         if newValue {
             let favorite = Favorite(toast: toastViewModel.toast)


### PR DESCRIPTION
## Summary
- remove the unused `toastId` local in `ToastListViewModel.toggleFavorite`
- clear warning #32 without changing favorite-toggle behavior

## User Flow
```mermaid
flowchart TD
  A[User taps favorite] --> B[toggleFavorite runs]
  B --> C[Favorite is saved or removed]
  C --> D[Same behavior, warning removed]
```

## Verification
- targeted check confirmed no remaining `toastId` usage in `ToastListViewModel.swift`
- `xcodebuild -workspace "letscheers.xcworkspace" -scheme App -configuration Debug -destination 'generic/platform=iOS Simulator' build` succeeded
- only `Projects/App/Sources/ViewModels/ToastListViewModel.swift` changed

## Issue
- closes #32
