### PR TITLE
fix: remove unused migrationResult warning

### DIFF
--- a/Projects/App/Sources/Screens/SplashScreen.swift
+++ b/Projects/App/Sources/Screens/SplashScreen.swift
@@ -52,7 +52,7 @@ struct SplashScreen: View {
     private func performInitialization() async {
         // Run migration if Core Data exists (handles favorites migration)
         // This will skip if already migrated or no Core Data exists
-        let migrationResult = await migrateToSwiftData()
+        _ = await migrateToSwiftData()
         await updateProgress(0.3)
 
         // Check if this is first launch or needs migration


### PR DESCRIPTION
## Summary
- replace the unused `migrationResult` local with an explicit ignored result in `SplashScreen.performInitialization`
- clear warning #31 without changing splash initialization behavior

## User Flow
```mermaid
flowchart TD
  A[App launches] --> B[SplashScreen performs initialization]
  B --> C[Migration still runs]
  C --> D[Initialization continues unchanged]
  D --> E[Warning removed]
```

## Verification
- confirmed the warning site now uses `_ = await migrateToSwiftData()`
- `xcodebuild -workspace "letscheers.xcworkspace" -scheme App -configuration Debug -destination 'generic/platform=iOS Simulator' build` succeeded
- only `Projects/App/Sources/Screens/SplashScreen.swift` changed in this PR

## Issue
- closes #31
