### PR TITLE
fix: update review prompt API

### DIFF
--- a/Projects/App/Sources/AppDelegate.swift
+++ b/Projects/App/Sources/AppDelegate.swift
@@ -34,8 +34,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ReviewManagerDelegate, GA
     func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
         guard LSDefaults.LaunchCount % reviewInterval != 0 else{
-            if #available(iOS 10.3, *) {
-                SKStoreReviewController.requestReview()
+            if let scene = application.connectedScenes
+                .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+                AppStore.requestReview(in: scene)
             }
             LSDefaults.increaseLaunchCount();
             return;


### PR DESCRIPTION
## Summary
- replace deprecated `SKStoreReviewController.requestReview()` usage with `AppStore.requestReview(in:)`
- keep the in-app review prompt flow aligned with the current iOS review API

## User Flow
```mermaid
flowchart TD
  A[App enters foreground on review interval] --> B[Find active window scene]
  B --> C[Request in-app review]
  C --> D[Launch count continues updating]
```

## Verification
- `xcodebuild -workspace "letscheers.xcworkspace" -scheme App -configuration Debug -destination 'generic/platform=iOS Simulator' build` succeeded
- the deprecated `SKStoreReviewController.requestReview()` call was removed from `AppDelegate.swift`
- only `Projects/App/Sources/AppDelegate.swift` changed in this PR

## Issue
- closes #33
