### PR TITLE
fix: remove deprecated keyWindow usage

### DIFF
--- a/Projects/App/Sources/Extensions/GADRewardManager.swift
+++ b/Projects/App/Sources/Extensions/GADRewardManager.swift
@@ -136,7 +136,7 @@ class GADRewardManager : NSObject{
          alert.dismiss(animated: false, completion: nil);
          }*/
         
-        guard !(UIApplication.shared.keyWindow?.rootViewController?.presentedViewController is UIAlertController) else{
+        guard !(self.window.rootViewController?.presentedViewController is UIAlertController) else{
             //alert.dismiss(animated: false, completion: nil);
             self.rewardAd = nil;
             return;


### PR DESCRIPTION
## Summary
- replace deprecated `UIApplication.shared.keyWindow` access in `GADRewardManager`
- keep the reward ad alert guard using the manager's existing root view controller source

## User Flow
```mermaid
flowchart TD
  A[Reward ad ready to present] --> B[Check current presented view controller]
  B --> C[Skip if alert is already shown]
  C --> D[Present reward ad normally]
```

## Verification
- `xcodebuild -workspace "letscheers.xcworkspace" -scheme App -configuration Debug -destination 'generic/platform=iOS Simulator' build` succeeded
- deprecated `keyWindow` usage was removed from `GADRewardManager.swift`
- only `Projects/App/Sources/Extensions/GADRewardManager.swift` changed in this PR

## Issue
- closes #29
