### PR TITLE
fix: remove deprecated windows usage

### DIFF
--- a/Projects/App/Sources/Extensions/GADRewardedAd+.swift
+++ b/Projects/App/Sources/Extensions/GADRewardedAd+.swift
@@ -12,7 +12,7 @@ import GoogleMobileAds
 extension GoogleMobileAds.RewardedAd{
     func isReady(for viewController: UIViewController? = nil) -> Bool{
         do{
-            if let viewController = viewController ?? UIApplication.shared.windows.first?.rootViewController{
+            if let viewController = viewController ?? (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first?.rootViewController{
                 try self.canPresent(from: viewController);
                 return true;
             }


### PR DESCRIPTION
## Summary
- replace deprecated `UIApplication.shared.windows` fallback in `GADRewardedAd.isReady`
- use a window scene-based root view controller lookup when no explicit view controller is provided

## User Flow
```mermaid
flowchart TD
  A[Check rewarded ad readiness] --> B{Explicit view controller?}
  B -->|Yes| C[Use provided controller]
  B -->|No| D[Find root controller from window scene]
  D --> E[Validate ad can present]
```

## Verification
- `xcodebuild -workspace "letscheers.xcworkspace" -scheme App -configuration Debug -destination 'generic/platform=iOS Simulator' build` succeeded
- deprecated `UIApplication.shared.windows` usage was removed from `GADRewardedAd+.swift`
- only `Projects/App/Sources/Extensions/GADRewardedAd+.swift` changed in this PR

## Issue
- closes #28
