### PR TITLE
bump: release 2.1.1

### DIFF
--- a/Projects/App/Configs/debug.xcconfig
+++ b/Projects/App/Configs/debug.xcconfig
@@ -6,7 +6,7 @@ ENABLE_BITCODE=NO
 EXCLUDED_ARCHS[sdk=iphonesimulator*]=i386
 INFOPLIST_FILE=letscheers/Info.plist
 INFOPLIST_KEY_LSApplicationCategoryType=public.app-category.lifestyle
-MARKETING_VERSION=2.1.0
+MARKETING_VERSION=2.1.1
 PRODUCT_BUNDLE_IDENTIFIER=com.credif.letscheers
 PRODUCT_NAME=$(TARGET_NAME)
 SUPPORTED_PLATFORMS=iphoneos iphonesimulator

--- a/Projects/App/Configs/release.xcconfig
+++ b/Projects/App/Configs/release.xcconfig
@@ -6,7 +6,7 @@ ENABLE_BITCODE=NO
 EXCLUDED_ARCHS[sdk=iphonesimulator*]=i386
 INFOPLIST_FILE=letscheers/Info.plist
 INFOPLIST_KEY_LSApplicationCategoryType=public.app-category.lifestyle
-MARKETING_VERSION=2.1.0
+MARKETING_VERSION=2.1.1
 PRODUCT_BUNDLE_IDENTIFIER=com.credif.letscheers
 PRODUCT_NAME=$(TARGET_NAME)
 SUPPORTED_PLATFORMS=iphoneos iphonesimulator


### PR DESCRIPTION
## Summary
- prepare the 2.1.1 patch release
- ship the latest cheers workbook refresh and recent warning/compatibility cleanups since 2.1.0

## Patch Notes
- refresh bundled cheers data with the latest `cheers.xlsx` content
- remove the unused `toastId` warning in `ToastListViewModel`
- remove the unused `migrationResult` warning in `SplashScreen`
- update the in-app review prompt call to the current StoreKit review API
- remove deprecated `keyWindow` usage in `GADRewardManager`
- remove deprecated `UIApplication.shared.windows` usage in `GADRewardedAd`

## App Store Release Note
- 최신 건배사 데이터로 내용을 업데이트했어요.
- 앱 안정성과 호환성을 함께 개선했어요.

## User Flow
```mermaid
flowchart TD
  A[App 2.1.1 launch] --> B[Load refreshed cheers workbook]
  B --> C[Browse updated toast content]
  A --> D[Run cleaned up app lifecycle and ad/review paths]
  D --> E[Same user flows with compatibility fixes]
```

## Verification
- bumped `MARKETING_VERSION` to `2.1.1` in debug and release configs
- `xcodebuild -workspace "letscheers.xcworkspace" -scheme App -configuration Debug -destination 'generic/platform=iOS Simulator' build` succeeded
- release branch contains only `bump: release 2.1.1`
