### PR TITLE
feat: automated monthly toast data update

### DIFF
--- a/.github/scripts/update_toasts.py
+++ b/.github/scripts/update_toasts.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+import json
+import os
+import subprocess
+
+import openpyxl
+
+XLSX_PATH = "Projects/App/Resources/Excel/cheers.xlsx"
+SHEET_NAME = "기본_건배사"
+PR_BODY_PATH = ".github/scripts/pr_body.md"
+
+
+def get_last_modified_date() -> str:
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%ci", f"{XLSX_PATH}.secret"],
+        capture_output=True,
+        text=True,
+    )
+    date = result.stdout.strip()
+    return date[:10] if date else "2024-01-01"
+
+
+def read_column_map(ws) -> dict:
+    return {cell.value: cell.column for cell in ws[1] if cell.value}
+
+
+def read_existing_toasts(ws, col_map: dict) -> tuple:
+    title_col = col_map.get("건배사")
+    no_col = col_map.get("no")
+    contents_col = col_map.get("의미")
+    category_col = col_map.get("분류")
+
+    existing = []
+    max_no = 0
+
+    for row in ws.iter_rows(min_row=2):
+        title_val = row[title_col - 1].value if title_col else None
+        if not title_val:
+            break
+
+        no_val = row[no_col - 1].value if no_col else None
+        contents_val = row[contents_col - 1].value if contents_col else ""
+        category_val = row[category_col - 1].value if category_col else ""
+
+        no = int(no_val) if no_val else 0
+        existing.append(
+            {
+                "no": no,
+                "title": title_val,
+                "contents": contents_val or "",
+                "category": category_val or "",
+            }
+        )
+        max_no = max(max_no, no)
+
+    return existing, max_no
+
+
+def search_new_toasts(existing_titles: set, categories: list, since_date: str) -> list:
+    existing_sample = "\n".join(list(existing_titles)[:50])
+    categories_str = ", ".join(categories)
+
+    prompt = f"""Search the web for new Korean 건배사 (drinking toast phrases) that have become popular or trending since {since_date}.
+
+Available categories: {categories_str}
+
+Existing toasts to avoid duplicating:
+{existing_sample}
+
+Find 5-10 new, creative, and culturally relevant Korean 건배사.
+Return ONLY a valid JSON array with no other text:
+[
+  {{"title": "건배사", "contents": "의미 설명", "category": "분류"}}
+]
+
+Rules:
+- title must not duplicate any existing toast
+- category must be one of: {categories_str}
+- contents should be the meaning or context in Korean"""
+
+    result = subprocess.run(
+        ["claude", "-p", prompt, "--print"],
+        capture_output=True,
+        text=True,
+    )
+
+    text = result.stdout.strip()
+    start = text.find("[")
+    end = text.rfind("]") + 1
+    if start != -1 and end > start:
+        try:
+            return json.loads(text[start:end])
+        except json.JSONDecodeError:
+            pass
+
+    return []
+
+
+def append_toast(ws, col_map: dict, no: int, title: str, contents: str, category: str):
+    next_row = ws.max_row + 1
+    if no_col := col_map.get("no"):
+        ws.cell(row=next_row, column=no_col).value = no
+    if title_col := col_map.get("건배사"):
+        ws.cell(row=next_row, column=title_col).value = title
+    if contents_col := col_map.get("의미"):
+        ws.cell(row=next_row, column=contents_col).value = contents
+    if category_col := col_map.get("분류"):
+        ws.cell(row=next_row, column=category_col).value = category
+
+
+def write_pr_body(new_toasts: list, since_date: str):
+    lines = [
+        "## 건배사 데이터 업데이트",
+        "",
+        f"**{since_date}** 이후 새로운 건배사 **{len(new_toasts)}개** 추가",
+        "",
+        "| 건배사 | 의미 | 분류 |",
+        "|--------|------|------|",
+    ]
+    for t in new_toasts:
+        lines.append(f"| {t['title']} | {t.get('contents', '')} | {t.get('category', '')} |")
+
+    with open(PR_BODY_PATH, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+
+def set_output(key: str, value: str):
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as f:
+            f.write(f"{key}={value}\n")
+    else:
+        print(f"OUTPUT: {key}={value}")
+
+
+def main():
+    wb = openpyxl.load_workbook(XLSX_PATH)
+    ws = wb[SHEET_NAME]
+
+    col_map = read_column_map(ws)
+    existing, max_no = read_existing_toasts(ws, col_map)
+    existing_titles = {t["title"] for t in existing}
+    categories = sorted({t["category"] for t in existing if t["category"]})
+
+    since_date = get_last_modified_date()
+    print(f"Existing toasts: {len(existing)}, since: {since_date}")
+    print(f"Categories: {categories}")
+
+    new_toasts = search_new_toasts(existing_titles, categories, since_date)
+    new_toasts = [t for t in new_toasts if t.get("title") and t["title"] not in existing_titles]
+
+    if not new_toasts:
+        print("No new toasts found")
+        set_output("has_new_toasts", "false")
+        return
+
+    print(f"Adding {len(new_toasts)} new toasts")
+    for toast in new_toasts:
+        max_no += 1
+        append_toast(ws, col_map, max_no, toast["title"], toast.get("contents", ""), toast.get("category", ""))
+
+    wb.save(XLSX_PATH)
+    write_pr_body(new_toasts, since_date)
+    set_output("has_new_toasts", "true")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/update_toasts.py
+++ b/.github/scripts/update_toasts.py
@@ -13,8 +13,7 @@ PR_BODY_PATH = ".github/scripts/pr_body.md"
 def get_last_modified_date() -> str:
     result = subprocess.run(
         ["git", "log", "-1", "--format=%ci", f"{XLSX_PATH}.secret"],
-        capture_output=True,
-        text=True,
+        capture_output=True, text=True,
     )
     date = result.stdout.strip()
     return date[:10] if date else "2024-01-01"
@@ -25,66 +24,50 @@ def read_column_map(ws) -> dict:
 
 
 def read_existing_toasts(ws, col_map: dict) -> tuple:
-    title_col = col_map.get("건배사")
     no_col = col_map.get("no")
+    title_col = col_map.get("건배사")
     contents_col = col_map.get("의미")
     category_col = col_map.get("분류")
 
-    existing = []
-    max_no = 0
-
+    existing, max_no = [], 0
     for row in ws.iter_rows(min_row=2):
         title_val = row[title_col - 1].value if title_col else None
         if not title_val:
             break
-
         no_val = row[no_col - 1].value if no_col else None
-        contents_val = row[contents_col - 1].value if contents_col else ""
-        category_val = row[category_col - 1].value if category_col else ""
-
         no = int(no_val) if no_val else 0
-        existing.append(
-            {
-                "no": no,
-                "title": title_val,
-                "contents": contents_val or "",
-                "category": category_val or "",
-            }
-        )
+        existing.append({
+            "no": no,
+            "title": title_val,
+            "contents": (row[contents_col - 1].value if contents_col else "") or "",
+            "category": (row[category_col - 1].value if category_col else "") or "",
+        })
         max_no = max(max_no, no)
 
     return existing, max_no
 
 
-def search_new_toasts(existing_titles: set, categories: list, since_date: str) -> list:
-    existing_sample = "\n".join(list(existing_titles)[:50])
+def search_new_toasts(categories: list, since_date: str) -> list:
     categories_str = ", ".join(categories)
-
-    prompt = f"""Search the web for new Korean 건배사 (drinking toast phrases) that have become popular or trending since {since_date}.
-
-Available categories: {categories_str}
-
-Existing toasts to avoid duplicating:
-{existing_sample}
-
-Find 5-10 new, creative, and culturally relevant Korean 건배사.
-Return ONLY a valid JSON array with no other text:
-[
-  {{"title": "건배사", "contents": "의미 설명", "category": "분류"}}
-]
-
-Rules:
-- title must not duplicate any existing toast
-- category must be one of: {categories_str}
-- contents should be the meaning or context in Korean"""
-
-    result = subprocess.run(
-        ["claude", "-p", prompt, "--print"],
-        capture_output=True,
-        text=True,
+    prompt = (
+        f"Search the web for new Korean 건배사 (drinking toast phrases) popular since {since_date}. "
+        f"Categories: {categories_str}. "
+        f"Find 10 new ones spread across categories. "
+        f"Return JSON array only: "
+        f'[{{"title":"건배사","contents":"의미","category":"분류"}}]'
     )
 
-    text = result.stdout.strip()
+    result = subprocess.run(
+        ["claude", "-p", prompt, "--output-format", "json"],
+        capture_output=True, text=True,
+    )
+
+    try:
+        data = json.loads(result.stdout)
+        text = data.get("result", "")
+    except (json.JSONDecodeError, KeyError):
+        text = result.stdout
+
     start = text.find("[")
     end = text.rfind("]") + 1
     if start != -1 and end > start:
@@ -116,10 +99,8 @@ def write_pr_body(new_toasts: list, since_date: str):
         "",
         "| 건배사 | 의미 | 분류 |",
         "|--------|------|------|",
+        *[f"| {t['title']} | {t.get('contents', '')} | {t.get('category', '')} |" for t in new_toasts],
     ]
-    for t in new_toasts:
-        lines.append(f"| {t['title']} | {t.get('contents', '')} | {t.get('category', '')} |")
-
     with open(PR_BODY_PATH, "w", encoding="utf-8") as f:
         f.write("\n".join(lines))
 
@@ -143,10 +124,9 @@ def main():
     categories = sorted({t["category"] for t in existing if t["category"]})
 
     since_date = get_last_modified_date()
-    print(f"Existing toasts: {len(existing)}, since: {since_date}")
-    print(f"Categories: {categories}")
+    print(f"Existing: {len(existing)} toasts | Since: {since_date} | Categories: {categories}")
 
-    new_toasts = search_new_toasts(existing_titles, categories, since_date)
+    new_toasts = search_new_toasts(categories, since_date)
     new_toasts = [t for t in new_toasts if t.get("title") and t["title"] not in existing_titles]
 
     if not new_toasts:

--- a/.github/scripts/update_toasts.py
+++ b/.github/scripts/update_toasts.py
@@ -59,8 +59,12 @@ def search_new_toasts(categories: list, since_date: str) -> list:
 
     result = subprocess.run(
         ["claude", "-p", prompt, "--output-format", "json"],
-        capture_output=True, text=True,
+        capture_output=True, text=True, timeout=120,
     )
+
+    if result.returncode != 0:
+        print(f"claude error: {result.stderr}")
+        return []
 
     try:
         data = json.loads(result.stdout)

--- a/.github/workflows/update-toast-data.yml
+++ b/.github/workflows/update-toast-data.yml
@@ -1,0 +1,84 @@
+name: UPDATE TOAST DATA
+
+on:
+  schedule:
+    - cron: '0 2 1 * *'  # Monthly, 1st at 02:00 UTC (11:00 KST)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    env:
+      GPG_PRIVATE_KEY_PATH: private.gpg
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Import GPG Key
+        run: |
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 -d > $GPG_PRIVATE_KEY_PATH
+          gpg --batch --no-tty --yes --import $GPG_PRIVATE_KEY_PATH
+          rm $GPG_PRIVATE_KEY_PATH
+
+      - name: Install git-secret
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y git-secret
+
+      - name: Decrypt xlsx
+        run: |
+          git secret reveal -p "${{ secrets.GPG_PRIVATE_PWD }}"
+
+      - name: Install Claude Code
+        run: |
+          npm install -g @anthropic-ai/claude-code
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python dependencies
+        run: |
+          pip install openpyxl
+
+      - name: Search and update toasts
+        id: update
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          python .github/scripts/update_toasts.py
+
+      - name: Re-encrypt xlsx
+        if: steps.update.outputs.has_new_toasts == 'true'
+        run: |
+          git secret hide
+
+      - name: Commit and create PR
+        if: steps.update.outputs.has_new_toasts == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          BRANCH="data/toast-update-$DATE"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+          git add Projects/App/Resources/Excel/cheers.xlsx.secret
+          git commit -m "data: 건배사 업데이트 $DATE"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "data: 건배사 업데이트 $DATE" \
+            --body-file .github/scripts/pr_body.md \
+            --base main \
+            --head "$BRANCH"

--- a/.github/workflows/update-toast-data.yml
+++ b/.github/workflows/update-toast-data.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     env:
       GPG_PRIVATE_KEY_PATH: private.gpg
 
@@ -21,29 +21,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Import GPG Key
+      - name: Import Secret Key
         run: |
-          echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 -d > $GPG_PRIVATE_KEY_PATH
+          echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d -o $GPG_PRIVATE_KEY_PATH
           gpg --batch --no-tty --yes --import $GPG_PRIVATE_KEY_PATH
-          rm $GPG_PRIVATE_KEY_PATH
-          gpg --batch --no-tty --yes --list-keys --fingerprint \
-            | grep -E "^      [0-9A-F]" | tr -d ' ' \
-            | awk '{print $1":6:"}' \
-            | gpg --batch --no-tty --import-ownertrust
 
-      - name: Install git-secret
+      - name: Install Encrypter
         run: |
-          curl -1sLf 'https://dl.cloudsmith.io/public/sobolevn/git-secret/gpg.D6B93412DBE6B994.key' \
-            | sudo gpg --dearmor -o /usr/share/keyrings/git-secret-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/git-secret-archive-keyring.gpg] \
-            https://dl.cloudsmith.io/public/sobolevn/git-secret/deb/ubuntu focal main" \
-            | sudo tee /etc/apt/sources.list.d/git-secret.list
-          sudo apt-get update -qq
-          sudo apt-get install -y git-secret
+          brew install git-secret
 
-      - name: Decrypt xlsx
+      - name: Decrypt Secret Data
         run: |
-          git secret reveal -p "${{ secrets.GPG_PRIVATE_PWD }}"
+          git secret reveal -p ${{ secrets.GPG_PRIVATE_PWD }}
 
       - name: Install Claude Code
         run: |

--- a/.github/workflows/update-toast-data.yml
+++ b/.github/workflows/update-toast-data.yml
@@ -26,9 +26,18 @@ jobs:
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 -d > $GPG_PRIVATE_KEY_PATH
           gpg --batch --no-tty --yes --import $GPG_PRIVATE_KEY_PATH
           rm $GPG_PRIVATE_KEY_PATH
+          gpg --batch --no-tty --yes --list-keys --fingerprint \
+            | grep -E "^      [0-9A-F]" | tr -d ' ' \
+            | awk '{print $1":6:"}' \
+            | gpg --batch --no-tty --import-ownertrust
 
       - name: Install git-secret
         run: |
+          curl -1sLf 'https://dl.cloudsmith.io/public/sobolevn/git-secret/gpg.D6B93412DBE6B994.key' \
+            | sudo gpg --dearmor -o /usr/share/keyrings/git-secret-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/git-secret-archive-keyring.gpg] \
+            https://dl.cloudsmith.io/public/sobolevn/git-secret/deb/ubuntu focal main" \
+            | sudo tee /etc/apt/sources.list.d/git-secret.list
           sudo apt-get update -qq
           sudo apt-get install -y git-secret
 
@@ -38,7 +47,7 @@ jobs:
 
       - name: Install Claude Code
         run: |
-          npm install -g @anthropic-ai/claude-code
+          npm install -g @anthropic-ai/claude-code@latest
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -71,6 +80,10 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code --heads origin "$BRANCH"; then
+            BRANCH="${BRANCH}-$(date +%H%M)"
+          fi
 
           git checkout -b "$BRANCH"
           git add Projects/App/Resources/Excel/cheers.xlsx.secret


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow that runs monthly (1st of each month, 11AM KST)
- Decrypts `cheers.xlsx` via git-secret, searches for new 건배사 using Claude Code CLI with web search
- Appends new toasts to xlsx, re-encrypts, creates PR automatically
- No-ops cleanly when no new toasts are found

## Flow

```mermaid
flowchart TD
    A[Cron: 1st of month] --> B[Decrypt cheers.xlsx]
    B --> C[Read existing toasts & categories]
    C --> D[claude -p: web search new 건배사]
    D --> E{New toasts found?}
    E -- No --> F[Exit cleanly]
    E -- Yes --> G[Append to xlsx]
    G --> H[git secret hide]
    H --> I[Create branch data/toast-update-DATE]
    I --> J[Create PR with toast table]
```

## Files

- `.github/workflows/update-toast-data.yml` — cron workflow
- `.github/scripts/update_toasts.py` — xlsx read/write + claude CLI call

## Required Secret

`CLAUDE_CODE_OAUTH_TOKEN` (already configured)