### PR TITLE
fix: dedupe toasts within batch and normalize titles

### DIFF
--- a/.github/scripts/update_toasts.py
+++ b/.github/scripts/update_toasts.py
@@ -47,6 +47,33 @@ def read_existing_toasts(ws, col_map: dict) -> tuple:
     return existing, max_no
 
 
+def normalize_text(value) -> str:
+    return str(value or "").strip()
+
+
+def filter_new_toasts(new_toasts: list, existing_titles: set) -> list:
+    filtered = []
+    seen_titles = set()
+
+    for toast in new_toasts:
+        title = normalize_text(toast.get("title"))
+        if not title:
+            continue
+
+        title_key = title
+        if title_key in existing_titles or title_key in seen_titles:
+            continue
+
+        seen_titles.add(title_key)
+        filtered.append({
+            "title": title,
+            "contents": normalize_text(toast.get("contents")),
+            "category": normalize_text(toast.get("category")),
+        })
+
+    return filtered
+
+
 def search_new_toasts(categories: list, since_date: str) -> list:
     categories_str = ", ".join(categories)
     prompt = (
@@ -124,14 +151,14 @@ def main():
 
     col_map = read_column_map(ws)
     existing, max_no = read_existing_toasts(ws, col_map)
-    existing_titles = {t["title"] for t in existing}
+    existing_titles = {normalize_text(t["title"]) for t in existing if normalize_text(t["title"])}
     categories = sorted({t["category"] for t in existing if t["category"]})
 
     since_date = get_last_modified_date()
     print(f"Existing: {len(existing)} toasts | Since: {since_date} | Categories: {categories}")
 
     new_toasts = search_new_toasts(categories, since_date)
-    new_toasts = [t for t in new_toasts if t.get("title") and t["title"] not in existing_titles]
+    new_toasts = filter_new_toasts(new_toasts, existing_titles)
 
     if not new_toasts:
         print("No new toasts found")

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,10 @@ Projects/App/Resources/Excel/cheers.xlsx
 
 ### Claude
 .claude/plans
+
+### Python
+__pycache__/
+*.pyc
+
+### opencode
+.opencode/

--- a/.serena/memories/marketing_preferences.md
+++ b/.serena/memories/marketing_preferences.md
@@ -1,0 +1,1 @@
+Preferred App Store promotion text for letscheers: "회식·술자리 건배제의, 이제 당황하지 마세요. 상황별 건배사를 쉽고 빠르게 찾아보세요." User selected this as the preferred final version.


### PR DESCRIPTION
## Problem

`update_toasts.py` filtered incoming toasts only against titles already in the sheet:

```python
new_toasts = [t for t in new_toasts if t.get("title") and t["title"] not in existing_titles]
```

Two failure modes:

1. **Intra-batch duplicates** — if the LLM returned the same title twice in one response, both rows were appended. Nothing compared new titles against each other.
2. **Whitespace variants** — `" 건배사 "` and `"건배사"` compared unequal, so a trimmed-vs-untrimmed pair slipped past as new.

## Changes

- `normalize_text(value)` — coerce to `str`, strip, `None` → `""`.
- `filter_new_toasts(new_toasts, existing_titles)` — replaces the inline filter:
  - drops empty titles
  - dedupes against the existing sheet **and** against a `seen_titles` set for the current batch
  - normalizes `title` / `contents` / `category` on the way out
- `existing_titles` is now built with `normalize_text` and drops blanks, so sheet-side whitespace no longer defeats the comparison.

## Notes

CI-only script — no app code, no user flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)