### PR TITLE
fix: compare toast titles ignoring internal whitespace

### DIFF
--- a/.github/scripts/update_toasts.py
+++ b/.github/scripts/update_toasts.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import json
 import os
+import re
 import subprocess
 
 import openpyxl
@@ -51,20 +52,27 @@ def normalize_text(value) -> str:
     return str(value or "").strip()
 
 
+def title_key(value) -> str:
+    """Comparison key for a toast title, ignoring all whitespace.
+
+    Titles arrive spaced inconsistently — a search can return 아프지말자 for a
+    sheet that already holds 아프지 말자, which reads as the same toast to a
+    user but not to a plain string compare.
+    """
+    return re.sub(r"\s+", "", normalize_text(value))
+
+
 def filter_new_toasts(new_toasts: list, existing_titles: set) -> list:
     filtered = []
-    seen_titles = set()
+    seen_titles = {title_key(t) for t in existing_titles}
 
     for toast in new_toasts:
         title = normalize_text(toast.get("title"))
-        if not title:
+        key = title_key(title)
+        if not key or key in seen_titles:
             continue
 
-        title_key = title
-        if title_key in existing_titles or title_key in seen_titles:
-            continue
-
-        seen_titles.add(title_key)
+        seen_titles.add(key)
         filtered.append({
             "title": title,
             "contents": normalize_text(toast.get("contents")),
@@ -151,7 +159,7 @@ def main():
 
     col_map = read_column_map(ws)
     existing, max_no = read_existing_toasts(ws, col_map)
-    existing_titles = {normalize_text(t["title"]) for t in existing if normalize_text(t["title"])}
+    existing_titles = {t["title"] for t in existing if normalize_text(t["title"])}
     categories = sorted({t["category"] for t in existing if t["category"]})
 
     since_date = get_last_modified_date()


### PR DESCRIPTION
## Problem

`filter_new_toasts` compared titles after `strip()` only:

```python
title = normalize_text(toast.get("title"))
title_key = title
if title_key in existing_titles or title_key in seen_titles:
```

Outer whitespace was handled, internal whitespace was not. A search result spaced differently from the sheet read as a brand new toast.

This is not hypothetical — the 2026-06-01 batch hit it. The search returned `아프지말자` while the sheet already held `아프지 말자` (no 182, added in #80). To a user those are the same toast; to the filter they were different. It was caught by hand while rebuilding #81, but nothing in the pipeline would have stopped it.

## Fix

```python
def title_key(value) -> str:
    return re.sub(r"\s+", "", normalize_text(value))
```

Both the existing-title set and the intra-batch `seen_titles` set are now keyed on it. Callers pass raw titles — the function normalizes on the way in, so a sheet cell with stray padding keys the same as a clean one.

## Verification

| Case | Kept |
|---|---|
| `아프지말자` vs sheet `아프지 말자` | 0 |
| `백세건강` vs sheet `백세건강` | 0 |
| `몸이보약이다` vs sheet `" 몸이 보약이다 "` | 0 |
| `새 건배사` + `새건배사` in one batch | 1 |
| `"   "` / `None` title | 0 |
| genuinely new title | 1 |
| `멀리  가자` + `멀리 가자` (collapse) | 1 |

`contents` / `category` normalization is unchanged.

## Note

Stacks cleanly with #81 — `append_toasts.py` there calls this same function, and passing already-normalized titles still keys correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
