### PR TITLE
ci: use Xcode 26.5 for deploy and build-test

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Select Xcode
       run: |
-        sudo xcode-select -s /Applications/Xcode_26.1.1.app
+        sudo xcode-select -s /Applications/Xcode_26.5.app
 
     - name: Install Mise
       uses: jdx/mise-action@v2

--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Select Xcode
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.1.1.app
+          sudo xcode-select -s /Applications/Xcode_26.5.app
 
       - name: Import Secret Key
         run: |


### PR DESCRIPTION
## 문제

2.1.2 배포([run 31071465011](https://github.com/2sem/letscheers/actions/runs/31071465011))가 archive 단계에서 실패했습니다.

```
xcodebuild: error: Found no destinations for the scheme 'App' and action archive.
```

패키지 해석과 프로젝트 생성은 모두 성공한 뒤였고, 실패는 22단계 중 20번째라 **Export IPA와 Upload는 실행되지 않았습니다.** App Store에는 아무것도 제출되지 않았습니다.

## 원인 추정

같은 Tuist 4.203.0, 같은 매니페스트로 로컬(Xcode 26.6)에서는 정상입니다.

```
$ xcodebuild -workspace letscheers.xcworkspace -scheme App -showdestinations
  { platform:iOS, id:dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder, name:Any iOS Device }
  ...

$ tuist xcodebuild archive -workspace letscheers.xcworkspace -scheme App -configuration Release
  → destination 해석 통과, 로컬 서명에서만 실패 (Release는 수동 서명)
```

스킴과 `tuist xcodebuild` 래퍼 모두 정상이라는 뜻입니다. 러너에서만 destination이 비어 나오는 것으로 보아, Xcode 26은 플랫폼 SDK를 온디맨드로 내려받으므로 러너의 Xcode 26.1.1에 iOS 플랫폼이 없는 상태로 판단됩니다.

## 변경

macos-26에서 도는 두 워크플로 모두 동일하게 올렸습니다.

```diff
# .github/workflows/deploy-ios.yml
-          sudo xcode-select -s /Applications/Xcode_26.1.1.app
+          sudo xcode-select -s /Applications/Xcode_26.5.app

# .github/workflows/build-test.yml
-        sudo xcode-select -s /Applications/Xcode_26.1.1.app
+        sudo xcode-select -s /Applications/Xcode_26.5.app
```

`build-test.yml`은 `tuist install`과 `tuist test`를 같은 러너에서 돌리므로 같은 iOS 플랫폼에 의존합니다. (현재 저장소에 테스트 타깃은 없어 `tuist test`는 사실상 no-op입니다.)

`renovate.yml`과 `claude.yml`은 ubuntu, `update-toast-data.yml`은 Xcode를 선택하지 않으므로 해당 없습니다.

## 확인 필요

이 변경은 **러너 이미지에 `Xcode_26.5.app`이 실제로 있어야** 유효합니다. 확인하지 못한 채 올린 것이라, 워크플로를 다시 돌렸을 때 `Select Xcode` 단계에서 실패하면 이미지에 없는 버전입니다. 그 경우 `ls /Applications/Xcode*.app`로 실제 목록을 확인하는 편이 빠릅니다.

**이 PR은 스스로 검증되지 않습니다.** `build-test.yml`의 트리거 경로가 `**/*.swift`와 `mise.toml`뿐이라 YAML만 바뀐 이 PR은 어느 쪽에도 걸리지 않습니다.

참고로 Tuist 업그레이드 PR의 build-test([run 31066941173](https://github.com/2sem/letscheers/actions/runs/31066941173))는 Xcode 26.1.1에서 성공했습니다. 다만 저장소에 테스트 타깃이 없어 `tuist test`가 destination을 해석하지 않았을 가능성이 높아, archive 실패 원인을 반박하는 근거로 보기는 어렵습니다.

## 별건: 트리거 경로 오타

path 필터가 `mise.toml`인데 실제 파일명은 `.mise.toml`입니다. 점으로 시작하는 파일은 이 글롭에 걸리지 않아, mise/Tuist 버전 변경만으로는 build-test가 돌지 않습니다. 이번 범위 밖이라 두었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

